### PR TITLE
Add C type to export

### DIFF
--- a/AI/Rete/Net.hs
+++ b/AI/Rete/Net.hs
@@ -15,6 +15,7 @@ module AI.Rete.Net
     , addProdP
 
       -- * Creating conditions
+    , C()
     , c
 
       -- * Variable value access


### PR DESCRIPTION
I am assuming that this type (but not value) constructor was meant to have been exported? This is used in the `addProd` and `addProdP` functions & so it is helpful to be able to add type signatures.

Also, I was wondering if you could provide a short usage example?

Thanks!
